### PR TITLE
xdebug_get_utime returns always 0

### DIFF
--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -141,21 +141,6 @@ char* xdebug_strrstr(const char* haystack, const char* needle)
 
 double xdebug_get_utime(void)
 {
-#ifdef HAVE_GETTIMEOFDAY
-	struct timeval tp;
-	long sec = 0L;
-	double msec = 0.0;
-
-	if (gettimeofday((struct timeval *) &tp, NULL) == 0) {
-		sec = tp.tv_sec;
-		msec = (double) (tp.tv_usec / MICRO_IN_SEC);
-
-		if (msec >= 1.0) {
-			msec -= (long) msec;
-		}
-		return msec + sec;
-	}
-#endif
 	return 0;
 }
 


### PR DESCRIPTION
Macos bad performance fix.

https://github.com/docker/for-mac/issues/3455
https://bugs.xdebug.org/view.php?id=1701